### PR TITLE
Adjust tracking name parsing

### DIFF
--- a/collector/tracking.go
+++ b/collector/tracking.go
@@ -96,10 +96,10 @@ func chronyFormatName(tracking chrony.Tracking) string {
 		return chrony.RefidToString(tracking.RefID)
 	} else {
 		names, err := net.LookupAddr(tracking.IPAddr.String())
-		if err != nil {
+		if err != nil || len(names) < 1 {
 			return tracking.IPAddr.String()
 		}
-		return strings.Join(names, ",")
+		return strings.TrimRight(names[0], ".")
 	}
 }
 


### PR DESCRIPTION
Make tracking name DNS lookup act more like gethostbyaddr.
* Use only the first result from `net.LookupAddr()`.
* Trim trailing dot on hostname.

Signed-off-by: SuperQ <superq@gmail.com>