### PR TITLE
Add System time (aka "current correction") metric

### DIFF
--- a/collector/tracking.go
+++ b/collector/tracking.go
@@ -61,6 +61,16 @@ var (
 		prometheus.GaugeValue,
 	}
 
+	trackingSystemTime = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, trackingSubsystem, "system_time_seconds"),
+			"Chrony tracking System time",
+			nil,
+			nil,
+		),
+		prometheus.GaugeValue,
+	}
+
 	trackingRemoteTracking = typedDesc{
 		prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, trackingSubsystem, "remote_reference"),
@@ -123,6 +133,9 @@ func (e Exporter) getTrackingMetrics(ch chan<- prometheus.Metric, client chrony.
 
 	ch <- trackingRefTime.mustNewConstMetric(float64(tracking.RefTime.UnixNano()) / 1e9)
 	level.Debug(e.logger).Log("msg", "Tracking Ref Time", "ref_time", tracking.RefTime)
+
+	ch <- trackingSystemTime.mustNewConstMetric(float64(tracking.CurrentCorrection))
+	level.Debug(e.logger).Log("msg", "Tracking System Time", "system_time", tracking.CurrentCorrection)
 
 	remoteTracking := 1.0
 	if tracking.IPAddr.Equal(trackingLocalIP) {

--- a/collector/tracking.go
+++ b/collector/tracking.go
@@ -54,7 +54,7 @@ var (
 	trackingRefTime = typedDesc{
 		prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, trackingSubsystem, "reference_timestamp_seconds"),
-			"Chrony tracking Refreence timestamp",
+			"Chrony tracking Reference timestamp",
 			nil,
 			nil,
 		),


### PR DESCRIPTION
Until now I've still  been using a slow, Python-based, scraping-chronyc-output-multiple-times exporter for my NTP metrics because it includes the current system time. This was still missing from chrony_exporter, so I figured I hunt down the missing value, add a bit of copypasta and voilà: System time, aka "current correction" (because it can be fast or slow of NTP time). As far as I can tell the value is correct.

Added bonus: drive-by fix for a typo.

Let me know if I did something terribly wrong!
