### PR TITLE
Add Root delay/dispersion metrics

### DIFF
--- a/collector/tracking.go
+++ b/collector/tracking.go
@@ -94,7 +94,7 @@ var (
 	trackingRootDelay = typedDesc{
 		prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, trackingSubsystem, "root_delay_seconds"),
-			"Chrony tracking total of all network path delays to the NTP root",
+			"This is the total of the network path delays to the stratum-1 computer from which the computer is ultimately synchronised",
 			nil,
 			nil,
 		),

--- a/collector/tracking.go
+++ b/collector/tracking.go
@@ -101,6 +101,16 @@ var (
 		prometheus.GaugeValue,
 	}
 
+	trackingRootDispersion = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, trackingSubsystem, "root_dispersion_seconds"),
+			"Chrony tracking total of all measurement errors to the NTP root",
+			nil,
+			nil,
+		),
+		prometheus.GaugeValue,
+	}
+
 	trackingStratum = typedDesc{
 		prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, trackingSubsystem, "stratum"),
@@ -159,6 +169,9 @@ func (e Exporter) getTrackingMetrics(ch chan<- prometheus.Metric, client chrony.
 
 	ch <- trackingRootDelay.mustNewConstMetric(tracking.RootDelay)
 	level.Debug(e.logger).Log("msg", "Tracking Root delay", "root_delay", tracking.RootDelay)
+
+	ch <- trackingRootDispersion.mustNewConstMetric(tracking.RootDispersion)
+	level.Debug(e.logger).Log("msg", "Tracking Root dispersion", "root_dispersion", tracking.RootDispersion)
 
 	ch <- trackingStratum.mustNewConstMetric(float64(tracking.Stratum))
 	level.Debug(e.logger).Log("msg", "Tracking Stratum", "stratum", tracking.Stratum)

--- a/collector/tracking.go
+++ b/collector/tracking.go
@@ -91,6 +91,16 @@ var (
 		prometheus.GaugeValue,
 	}
 
+	trackingRootDelay = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, trackingSubsystem, "root_delay_seconds"),
+			"Chrony tracking total of all network path delays to the NTP root",
+			nil,
+			nil,
+		),
+		prometheus.GaugeValue,
+	}
+
 	trackingStratum = typedDesc{
 		prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, trackingSubsystem, "stratum"),
@@ -146,6 +156,9 @@ func (e Exporter) getTrackingMetrics(ch chan<- prometheus.Metric, client chrony.
 
 	ch <- trackingRMSOffset.mustNewConstMetric(tracking.RMSOffset)
 	level.Debug(e.logger).Log("msg", "Tracking RMS Offset", "rms_offset", tracking.RMSOffset)
+
+	ch <- trackingRootDelay.mustNewConstMetric(tracking.RootDelay)
+	level.Debug(e.logger).Log("msg", "Tracking Root delay", "root_delay", tracking.RootDelay)
 
 	ch <- trackingStratum.mustNewConstMetric(float64(tracking.Stratum))
 	level.Debug(e.logger).Log("msg", "Tracking Stratum", "stratum", tracking.Stratum)


### PR DESCRIPTION
This adds two additional metrics: Root delay & -dispersion.
I hope I got the abbreviated descriptions right; they were taken from [the man page](https://chrony.tuxfamily.org/doc/4.3/chronyc.html).
