### PR TITLE
Update crossbuild

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: install Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.21.x
       - name: Install snmp_exporter/generator dependencies

--- a/.promu.yml
+++ b/.promu.yml
@@ -2,7 +2,6 @@ go:
   # Whenever the Go version is updated here,
   # .circleci/config.yml should also be updated.
   version: 1.21
-
 repository:
   path: github.com/superq/chrony_exporter
 build:
@@ -15,6 +14,3 @@ build:
 tarball:
   files:
     - LICENSE
-crossbuild:
-  platforms:
-    - linux


### PR DESCRIPTION
* Remove crossbuild restriction to build all default platforms.
* Bump github actions.

Fixes: https://github.com/SuperQ/chrony_exporter/issues/60