### PR TITLE
Add serverstats metrics collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Supported parameters include:
 - `--chrony.address`: the address/port (UDP) or path to Unix socket used to connect to chrony (default: `"[::1]:323"`)
 - `--collector.sources`: Enable/disable the collection of `chronyc sources` metrics. (Default: Disabled)
 - `--collector.tracking`: Enable/disable the collection of `chronyc tracking` metrics. (Default: Enabled)
+- `--collector.serverstats`: Enable/disable the collection of `chronyc serverstats` metrics. (Default: Disabled)
 - `--collector.dns-lookups`: Enable/disable reverse DNS Lookups. (Default: Enabled)
 
 To disable a collector, use `--no-`. (i.e. `--no-collector.tracking`)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Supported parameters include:
 - `--chrony.address`: the address/port (UDP) or path to Unix socket used to connect to chrony (default: `"[::1]:323"`)
 - `--collector.sources`: Enable/disable the collection of `chronyc sources` metrics. (Default: Disabled)
 - `--collector.tracking`: Enable/disable the collection of `chronyc tracking` metrics. (Default: Enabled)
-- `--collector.serverstats`: Enable/disable the collection of `chronyc serverstats` metrics. (Default: Disabled)
+- `--collector.serverstats`: Enable/disable the collection of `chronyc serverstats` metrics. This collector only works when chrony is accessed through the Unix socket. (Default: Disabled)
 - `--collector.dns-lookups`: Enable/disable reverse DNS Lookups. (Default: Enabled)
 
 To disable a collector, use `--no-`. (i.e. `--no-collector.tracking`)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -49,10 +49,11 @@ type Exporter struct {
 	address string
 	timeout time.Duration
 
-	collectSources  bool
-	collectTracking bool
-	chmodSocket     bool
-	dnsLookups      bool
+	collectSources     bool
+	collectTracking    bool
+	collectServerstats bool
+	chmodSocket        bool
+	dnsLookups         bool
 
 	logger log.Logger
 }
@@ -82,6 +83,8 @@ type ChronyCollectorConfig struct {
 	CollectSources bool
 	// CollectTracking will configure the exporter to collect `chronyc tracking`.
 	CollectTracking bool
+	// CollectServerstats will configure the exporter to collect `chronyc serverstats`.
+	CollectServerstats bool
 }
 
 func NewExporter(conf ChronyCollectorConfig, logger log.Logger) Exporter {
@@ -89,10 +92,11 @@ func NewExporter(conf ChronyCollectorConfig, logger log.Logger) Exporter {
 		address: conf.Address,
 		timeout: conf.Timeout,
 
-		collectSources:  conf.CollectSources,
-		collectTracking: conf.CollectTracking,
-		chmodSocket:     conf.ChmodSocket,
-		dnsLookups:      conf.DNSLookups,
+		collectSources:     conf.CollectSources,
+		collectTracking:    conf.CollectTracking,
+		collectServerstats: conf.CollectServerstats,
+		chmodSocket:        conf.ChmodSocket,
+		dnsLookups:         conf.DNSLookups,
 
 		logger: logger,
 	}
@@ -159,6 +163,14 @@ func (e Exporter) Collect(ch chan<- prometheus.Metric) {
 		err = e.getTrackingMetrics(ch, client)
 		if err != nil {
 			level.Debug(e.logger).Log("msg", "Couldn't get tracking", "err", err)
+			up = 0
+		}
+	}
+
+	if e.collectServerstats {
+		err = e.getServerstatsMetrics(ch, client)
+		if err != nil {
+			level.Debug(e.logger).Log("msg", "Couldn't get serverstats", "err", err)
 			up = 0
 		}
 	}

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -28,8 +28,8 @@ const (
 var (
 	serverstatsNTPHits = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_hits"),
-			"Received NTP packets from allowed senders",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_packets_received_total"),
+			"The number of valid NTP requests received by the server.",
 			nil,
 			nil,
 		),
@@ -38,8 +38,8 @@ var (
 
 	serverstatsNKEHits = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nke_hits"),
-			"Accepted NTS-KE connections",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nts-ke_connections_accepted_total"),
+			"The number of NTS-KE connections accepted by the server.",
 			nil,
 			nil,
 		),
@@ -48,8 +48,8 @@ var (
 
 	serverstatsCMDHits = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "cmd_hits"),
-			"Received command packets",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "command_packets_received_total"),
+			"The number of command requests received by the server.",
 			nil,
 			nil,
 		),
@@ -58,8 +58,8 @@ var (
 
 	serverstatsNTPDrops = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_drops"),
-			"Dropped NTP packets",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_packets_dropped_total"),
+			"The number of NTP requests dropped by the server due to rate limiting.",
 			nil,
 			nil,
 		),
@@ -68,8 +68,8 @@ var (
 
 	serverstatsNKEDrops = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nke_drops"),
-			"Dropped NTS-KE connections",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nts-ke_connections_dropped_total"),
+			"The number of NTS-KE connections dropped by the server due to rate limiting.",
 			nil,
 			nil,
 		),
@@ -78,8 +78,8 @@ var (
 
 	serverstatsCMDDrops = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "cmd_drops"),
-			"Dropped command packets",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "command_packets_dropped_total"),
+			"The number of command requests dropped by the server due to rate limiting.",
 			nil,
 			nil,
 		),
@@ -88,8 +88,8 @@ var (
 
 	serverstatsLogDrops = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "log_drops"),
-			"Dropped log entries",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "client_log_records_dropped_total"),
+			"The number of client log records dropped by the server to limit the memory use.",
 			nil,
 			nil,
 		),
@@ -98,8 +98,8 @@ var (
 
 	serverstatsNTPAuthHits = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_auth_hits"),
-			"Authenticated NTP packets",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "auhtenticated_ntp_packets_total"),
+			"The number of received NTP requests that were authenticated (with a symmetric key or NTS).",
 			nil,
 			nil,
 		),
@@ -108,8 +108,8 @@ var (
 
 	serverstatsNTPInterleavedHits = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_interleaved_hits"),
-			"Interleaved NTP packets",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "interleaved_ntp_packets_total"),
+			"The number of received NTP requests that were detected to be in the interleaved mode.",
 			nil,
 			nil,
 		),
@@ -119,7 +119,7 @@ var (
 	serverstatsNTPTimestamps = typedDesc{
 		prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamps_held"),
-			"NTP timestamps held",
+			"The number of pairs of receive and transmit timestamps that the server is currently holding in memory for clients using the interleaved mode.",
 			nil,
 			nil,
 		),
@@ -128,8 +128,8 @@ var (
 
 	serverstatsNTPSpanSeconds = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamps_span"),
-			"NTP timestamp span",
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamp_span"),
+			"The interval (in seconds) covered by the currently held NTP timestamps.",
 			nil,
 			nil,
 		),

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -128,7 +128,7 @@ var (
 
 	serverstatsNTPSpanSeconds = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamp_span"),
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamp_span_seconds"),
 			"The interval (in seconds) covered by the currently held NTP timestamps.",
 			nil,
 			nil,

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -38,7 +38,7 @@ var (
 
 	serverstatsNKEHits = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nts-ke_connections_accepted_total"),
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nts_ke_connections_accepted_total"),
 			"The number of NTS-KE connections accepted by the server.",
 			nil,
 			nil,

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -68,7 +68,7 @@ var (
 
 	serverstatsNKEDrops = typedDesc{
 		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nts-ke_connections_dropped_total"),
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nts_ke_connections_dropped_total"),
 			"The number of NTS-KE connections dropped by the server due to rate limiting.",
 			nil,
 			nil,

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -1,0 +1,186 @@
+// Copyright 2022 Ben Kochie
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+
+	"github.com/facebook/time/ntp/chrony"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	serverstatsSubsystem = "serverstats"
+)
+
+var (
+	serverstatsNTPHits = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_hits"),
+			"Received NTP packets from allowed senders",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsNKEHits = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nke_hits"),
+			"Accepted NTS-KE connections",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsCMDHits = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "cmd_hits"),
+			"Received command packets",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsNTPDrops = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_drops"),
+			"Dropped NTP packets",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsNKEDrops = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "nke_drops"),
+			"Dropped NTS-KE connections",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsCMDDrops = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "cmd_drops"),
+			"Dropped command packets",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsLogDrops = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "log_drops"),
+			"Dropped log entries",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsNTPAuthHits = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_auth_hits"),
+			"Authenticated NTP packets",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsNTPInterleavedHits = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_interleaved_hits"),
+			"Interleaved NTP packets",
+			nil,
+			nil,
+		),
+		prometheus.CounterValue,
+	}
+
+	serverstatsNTPTimestamps = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamps_held"),
+			"NTP timestamps held",
+			nil,
+			nil,
+		),
+		prometheus.GaugeValue,
+	}
+
+	serverstatsNTPSpanSeconds = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, serverstatsSubsystem, "ntp_timestamps_span"),
+			"NTP timestamp span",
+			nil,
+			nil,
+		),
+		prometheus.GaugeValue,
+	}
+)
+
+func (e Exporter) getServerstatsMetrics(ch chan<- prometheus.Metric, client chrony.Client) error {
+	packet, err := client.Communicate(chrony.NewServerStatsPacket())
+	if err != nil {
+		return err
+	}
+	level.Debug(e.logger).Log("msg", "Got 'serverstats' response", "serverstats_packet", packet.GetStatus())
+
+	serverstats, ok := packet.(*chrony.ReplyServerStats3)
+	if !ok {
+		return fmt.Errorf("Got wrong 'serverstats' response: %q", packet)
+	}
+
+	ch <- serverstatsNTPHits.mustNewConstMetric(float64(serverstats.NTPHits))
+	level.Debug(e.logger).Log("msg", "Serverstats NTP Hits", "ntp_hits", serverstats.NTPHits)
+
+	ch <- serverstatsNKEHits.mustNewConstMetric(float64(serverstats.NKEHits))
+	level.Debug(e.logger).Log("msg", "Serverstats NKE Hits", "nke_hits", serverstats.NKEHits)
+
+	ch <- serverstatsCMDHits.mustNewConstMetric(float64(serverstats.CMDHits))
+	level.Debug(e.logger).Log("msg", "Serverstats CMD Hits", "cmd_hits", serverstats.CMDHits)
+
+	ch <- serverstatsNTPDrops.mustNewConstMetric(float64(serverstats.NTPDrops))
+	level.Debug(e.logger).Log("msg", "Serverstats NTP Drops", "ntp_drops", serverstats.NTPDrops)
+
+	ch <- serverstatsNKEDrops.mustNewConstMetric(float64(serverstats.NKEDrops))
+	level.Debug(e.logger).Log("msg", "Serverstats NKE Drops", "nke_drops", serverstats.NKEDrops)
+
+	ch <- serverstatsCMDDrops.mustNewConstMetric(float64(serverstats.CMDDrops))
+	level.Debug(e.logger).Log("msg", "Serverstats CMD Drops", "cmd_drops", serverstats.CMDDrops)
+
+	ch <- serverstatsLogDrops.mustNewConstMetric(float64(serverstats.LogDrops))
+	level.Debug(e.logger).Log("msg", "Serverstats Log Drops", "log_drops", serverstats.LogDrops)
+
+	ch <- serverstatsNTPAuthHits.mustNewConstMetric(float64(serverstats.NTPAuthHits))
+	level.Debug(e.logger).Log("msg", "Serverstats Authenticated Packets", "auth_hits", serverstats.NTPAuthHits)
+
+	ch <- serverstatsNTPInterleavedHits.mustNewConstMetric(float64(serverstats.NTPInterleavedHits))
+	level.Debug(e.logger).Log("msg", "Serverstats Interleaved Packets", "interleaved_hits", serverstats.NTPInterleavedHits)
+
+	ch <- serverstatsNTPTimestamps.mustNewConstMetric(float64(serverstats.NTPTimestamps))
+	level.Debug(e.logger).Log("msg", "Serverstats Timestamps Held", "ntp_timestamps_held", serverstats.NTPTimestamps)
+
+	ch <- serverstatsNTPSpanSeconds.mustNewConstMetric(float64(serverstats.NTPSpanSeconds))
+	level.Debug(e.logger).Log("msg", "Serverstats Timestamps Span", "ntp_timestamps_span", serverstats.NTPSpanSeconds)
+
+	return nil
+}

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Ben Kochie
+// Copyright 2024 Ben Kochie
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -146,7 +146,7 @@ func (e Exporter) getServerstatsMetrics(ch chan<- prometheus.Metric, client chro
 
 	serverstats, ok := packet.(*chrony.ReplyServerStats3)
 	if !ok {
-		return fmt.Errorf("Got wrong 'serverstats' response: %q", packet)
+		return fmt.Errorf("got wrong 'serverstats' response: %q", packet)
 	}
 
 	ch <- serverstatsNTPHits.mustNewConstMetric(float64(serverstats.NTPHits))

--- a/main.go
+++ b/main.go
@@ -58,6 +58,11 @@ func main() {
 	).Default("false").BoolVar(&conf.CollectSources)
 
 	kingpin.Flag(
+		"collector.serverstats",
+		"Collect serverstats metrics",
+	).Default("false").BoolVar(&conf.CollectServerstats)
+
+	kingpin.Flag(
 		"collector.chmod-socket",
 		"Chmod 0666 the receiving unix datagram socket",
 	).Default("false").BoolVar(&conf.ChmodSocket)


### PR DESCRIPTION
### What
I added a new collector for the "serverstats" metrics from chrony. It simply takes the numbers returned by "chronyc serverstats" and parses them into prometheus metrics.

The collector is disabled by default, so the default behavior of the exporter was not changed. Also, the exporter connects to chrony over a websocket by default, which does not work with the serverstats command (see [chronyc documentation](https://chrony-project.org/doc/4.4/chronyc.html), under "Description"). I've added a remark on that in the readme-line of the new collector..

### How (technical)
I basically copied the tracking metrics collector and rewrote the parameters and function names to fit the serverstats metrics. It uses the same library to interact with chrony and constructs the metrics in the same way.

I used prometheus counters for most of the new metrics since that fit the use case better - the stats are just request counters and monotonically increase over the runtime of a chrony server process. Only the "timestamp" metrics are not monotonic, so they are gauges.

The serverstats did not require any preprocessing - they are just integers that can be directly casted into the metrics.

### Why
I host some publicly available chrony servers and want some better insights into them.

### Proof of concept
I compiled the code with the changes, put it onto one of my time servers and started it with the required flags. Picture from my Prometheus web ui:
![grafik](https://github.com/SuperQ/chrony_exporter/assets/61566539/7d884fc0-442b-4f3a-922b-ce57d0dc0b89)