### PR TITLE
Improve DNS lookup debugging

### DIFF
--- a/collector/serverstats.go
+++ b/collector/serverstats.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/facebook/time/ntp/chrony"
+	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -137,12 +138,12 @@ var (
 	}
 )
 
-func (e Exporter) getServerstatsMetrics(ch chan<- prometheus.Metric, client chrony.Client) error {
+func (e Exporter) getServerstatsMetrics(logger log.Logger, ch chan<- prometheus.Metric, client chrony.Client) error {
 	packet, err := client.Communicate(chrony.NewServerStatsPacket())
 	if err != nil {
 		return err
 	}
-	level.Debug(e.logger).Log("msg", "Got 'serverstats' response", "serverstats_packet", packet.GetStatus())
+	level.Debug(logger).Log("msg", "Got 'serverstats' response", "serverstats_packet", packet.GetStatus())
 
 	serverstats, ok := packet.(*chrony.ReplyServerStats3)
 	if !ok {
@@ -150,37 +151,37 @@ func (e Exporter) getServerstatsMetrics(ch chan<- prometheus.Metric, client chro
 	}
 
 	ch <- serverstatsNTPHits.mustNewConstMetric(float64(serverstats.NTPHits))
-	level.Debug(e.logger).Log("msg", "Serverstats NTP Hits", "ntp_hits", serverstats.NTPHits)
+	level.Debug(logger).Log("msg", "Serverstats NTP Hits", "ntp_hits", serverstats.NTPHits)
 
 	ch <- serverstatsNKEHits.mustNewConstMetric(float64(serverstats.NKEHits))
-	level.Debug(e.logger).Log("msg", "Serverstats NKE Hits", "nke_hits", serverstats.NKEHits)
+	level.Debug(logger).Log("msg", "Serverstats NKE Hits", "nke_hits", serverstats.NKEHits)
 
 	ch <- serverstatsCMDHits.mustNewConstMetric(float64(serverstats.CMDHits))
-	level.Debug(e.logger).Log("msg", "Serverstats CMD Hits", "cmd_hits", serverstats.CMDHits)
+	level.Debug(logger).Log("msg", "Serverstats CMD Hits", "cmd_hits", serverstats.CMDHits)
 
 	ch <- serverstatsNTPDrops.mustNewConstMetric(float64(serverstats.NTPDrops))
-	level.Debug(e.logger).Log("msg", "Serverstats NTP Drops", "ntp_drops", serverstats.NTPDrops)
+	level.Debug(logger).Log("msg", "Serverstats NTP Drops", "ntp_drops", serverstats.NTPDrops)
 
 	ch <- serverstatsNKEDrops.mustNewConstMetric(float64(serverstats.NKEDrops))
-	level.Debug(e.logger).Log("msg", "Serverstats NKE Drops", "nke_drops", serverstats.NKEDrops)
+	level.Debug(logger).Log("msg", "Serverstats NKE Drops", "nke_drops", serverstats.NKEDrops)
 
 	ch <- serverstatsCMDDrops.mustNewConstMetric(float64(serverstats.CMDDrops))
-	level.Debug(e.logger).Log("msg", "Serverstats CMD Drops", "cmd_drops", serverstats.CMDDrops)
+	level.Debug(logger).Log("msg", "Serverstats CMD Drops", "cmd_drops", serverstats.CMDDrops)
 
 	ch <- serverstatsLogDrops.mustNewConstMetric(float64(serverstats.LogDrops))
-	level.Debug(e.logger).Log("msg", "Serverstats Log Drops", "log_drops", serverstats.LogDrops)
+	level.Debug(logger).Log("msg", "Serverstats Log Drops", "log_drops", serverstats.LogDrops)
 
 	ch <- serverstatsNTPAuthHits.mustNewConstMetric(float64(serverstats.NTPAuthHits))
-	level.Debug(e.logger).Log("msg", "Serverstats Authenticated Packets", "auth_hits", serverstats.NTPAuthHits)
+	level.Debug(logger).Log("msg", "Serverstats Authenticated Packets", "auth_hits", serverstats.NTPAuthHits)
 
 	ch <- serverstatsNTPInterleavedHits.mustNewConstMetric(float64(serverstats.NTPInterleavedHits))
-	level.Debug(e.logger).Log("msg", "Serverstats Interleaved Packets", "interleaved_hits", serverstats.NTPInterleavedHits)
+	level.Debug(logger).Log("msg", "Serverstats Interleaved Packets", "interleaved_hits", serverstats.NTPInterleavedHits)
 
 	ch <- serverstatsNTPTimestamps.mustNewConstMetric(float64(serverstats.NTPTimestamps))
-	level.Debug(e.logger).Log("msg", "Serverstats Timestamps Held", "ntp_timestamps_held", serverstats.NTPTimestamps)
+	level.Debug(logger).Log("msg", "Serverstats Timestamps Held", "ntp_timestamps_held", serverstats.NTPTimestamps)
 
 	ch <- serverstatsNTPSpanSeconds.mustNewConstMetric(float64(serverstats.NTPSpanSeconds))
-	level.Debug(e.logger).Log("msg", "Serverstats Timestamps Span", "ntp_timestamps_span", serverstats.NTPSpanSeconds)
+	level.Debug(logger).Log("msg", "Serverstats Timestamps Span", "ntp_timestamps_span", serverstats.NTPSpanSeconds)
 
 	return nil
 }


### PR DESCRIPTION
Rework DNS lookups in order to improve debugging
* Create a unified reverse DNS lookup function.
* Add lookup timing logging
* Add a scrape ID to the logger to identify concurrent scrapes.