### PR TITLE
Enhance "sources" information with NtpData response

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Flags:
       --chrony.timeout=5s        Timeout on requests to the Chrony srever.
       --[no-]collector.tracking  Collect tracking metrics
       --[no-]collector.sources   Collect sources metrics
+      --[no-]collector.sources.with-ntpdata  
+                                 Extend sources with ntpdata metrics (requires socket connection)
       --[no-]collector.serverstats  
                                  Collect serverstats metrics
       --[no-]collector.chmod-socket  

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -55,6 +55,7 @@ type Exporter struct {
 	timeout time.Duration
 
 	collectSources     bool
+	collectNtpdata     bool
 	collectTracking    bool
 	collectServerstats bool
 	chmodSocket        bool
@@ -86,6 +87,8 @@ type ChronyCollectorConfig struct {
 
 	// CollectSources will configure the exporter to collect `chronyc sources`.
 	CollectSources bool
+	// CollectNtpData will configure the exporter to extend sources info with `chronyc ntpdata`
+	CollectNtpdata bool
 	// CollectTracking will configure the exporter to collect `chronyc tracking`.
 	CollectTracking bool
 	// CollectServerstats will configure the exporter to collect `chronyc serverstats`.
@@ -98,6 +101,7 @@ func NewExporter(conf ChronyCollectorConfig, logger *slog.Logger) Exporter {
 		timeout: conf.Timeout,
 
 		collectSources:     conf.CollectSources,
+		collectNtpdata:     conf.CollectNtpdata,
 		collectTracking:    conf.CollectTracking,
 		collectServerstats: conf.CollectServerstats,
 		chmodSocket:        conf.ChmodSocket,
@@ -161,7 +165,7 @@ func (e Exporter) Collect(ch chan<- prometheus.Metric) {
 	client := chrony.Client{Sequence: 1, Connection: conn}
 
 	if e.collectSources {
-		err = e.getSourcesMetrics(logger, ch, client)
+		err = e.getSourcesMetrics(logger, ch, client, e.collectNtpdata)
 		if err != nil {
 			logger.Debug("Couldn't get sources", "err", err)
 			up = 0

--- a/main.go
+++ b/main.go
@@ -58,6 +58,11 @@ func main() {
 	).Default("false").BoolVar(&conf.CollectSources)
 
 	kingpin.Flag(
+		"collector.sources.with-ntpdata",
+		"Extend sources with ntpdata metrics (requires socket connection)",
+	).Default("false").BoolVar(&conf.CollectNtpdata)
+
+	kingpin.Flag(
 		"collector.serverstats",
 		"Collect serverstats metrics",
 	).Default("false").BoolVar(&conf.CollectServerstats)


### PR DESCRIPTION
We would like to extend source information with some peer details which can be retrieved via the `NtpData` resource.

This PR extends the "sources" information with additional peer/source information from the NtpData response. Namely it adds:

- Offset
- Peer Delay
- Peer Dispersion
- Peer Response Time
- Peer Jitter Asymmetry

What do you think about the implementation? Since the current `main` build does not work (crashes with logging issues when set to `debug` log level) we developed/tested this against the latest release tag.