### PR TITLE
Workaround debug logging panic

### DIFF
--- a/collector/sources.go
+++ b/collector/sources.go
@@ -125,7 +125,7 @@ func (e Exporter) getSourcesMetrics(logger *slog.Logger, ch chan<- prometheus.Me
 	results := make([]chrony.ReplySourceData, sources.NSources)
 
 	for i := 0; i < int(sources.NSources); i++ {
-		logger.Debug("Fetching source", "source", i)
+		logger.Debug("Fetching source", "source_index", i)
 		packet, err = client.Communicate(chrony.NewSourceDataPacket(int32(i)))
 		if err != nil {
 			return fmt.Errorf("Failed to get sourcedata response: %d", i)


### PR DESCRIPTION
Using the key `source` in promslog causes it to panic due to
having a duplicate key for the `source` filename.

Fixes: https://github.com/SuperQ/chrony_exporter/issues/107