### PR TITLE
Fix collector.sources.with-ntpdata for chrony >= 4.6

### DIFF
--- a/collector/sources.go
+++ b/collector/sources.go
@@ -213,10 +213,17 @@ func (e Exporter) getSourcesMetrics(logger *slog.Logger, ch chan<- prometheus.Me
 			if err != nil {
 				return fmt.Errorf("Failed to get ntpdata response for: %s", r.IPAddr)
 			}
-			ntpData, ok := ntpDataPacket.(*chrony.ReplyNTPData)
-			if !ok {
+
+			var ntpData *chrony.NTPData
+			switch rpyNTPData := ntpDataPacket.(type) {
+			case *chrony.ReplyNTPData:
+				ntpData = &rpyNTPData.NTPData
+			case *chrony.ReplyNTPData2:
+				ntpData = &rpyNTPData.NTPData
+			default:
 				return fmt.Errorf("Got wrong 'ntpdata' response: %q", packet)
 			}
+
 			ch <- sourcesPeerOffset.mustNewConstMetric(ntpData.Offset, sourceAddress, sourceName)
 			ch <- sourcesPeerDelay.mustNewConstMetric(ntpData.PeerDelay, sourceAddress, sourceName)
 			ch <- sourcesPeerResponseTime.mustNewConstMetric(ntpData.ResponseTime, sourceAddress, sourceName)


### PR DESCRIPTION
Starting with `chronyd` version `4.6`, the `ntpdata` report additionally contains timestamp sources. To support these additional fields a new reply type `RPY_NTP_DATA2` was introduced in `chrony`, see [1].

As consequence, the response to a `REQ_NTP_DATA` can be either `RPY_NTP_DATA` or the newly introduced `RPY_NTP_DATA2`. Since only the former is currently handled in `chrony_exporter`, activating extended source metric collection with `--collector.sources.with-ntpdata` will break metrics for all `chrony` versions starting with 4.6.

```
time=2025-05-02T20:18:18.217Z level=DEBUG source=collector.go:170 msg="Couldn't get sources" scrape_id=3 err="Got wrong 'ntpdata' response: &{{'\\x06' \"reply\" '\\x00' '\\x00' '\\x0f' '\\x03' \"SUCCESS\" '\\x00' '\\x00' '\\x00' '\\x04' '\\x00' '\\x00'} {\"192.0.2.123\" '\\n' '\\x02' \"candidate\" \"client\" '\\x00' 'ÿ' '͗' %!q(float64=-4.734699905384332e-05) %!q(float64=-4.315918340580538e-05) %!q(float64=0.0028017524164170027)}}"
```

This implements handling for both reply types.

[1] https://gitlab.com/chrony/chrony/-/commit/eb26d13140bf74e01e8fa63adc9e799ed5555883