### PR TITLE
Fix socket client filename

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/facebook/time/ntp/chrony"
+	"github.com/google/uuid"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -119,7 +121,7 @@ func (e Exporter) dial() (net.Conn, func(), error) {
 	if strings.HasPrefix(e.address, "unix://") {
 		remote := strings.TrimPrefix(e.address, "unix://")
 		base, _ := path.Split(remote)
-		local := path.Join(base, fmt.Sprintf("chrony_exporter.%d.sock", os.Getpid()))
+		local := path.Join(base, fmt.Sprintf("chrony_exporter.%s.sock", uuid.New()))
 		conn, err := net.DialUnix("unixgram",
 			&net.UnixAddr{Name: local, Net: "unixgram"},
 			&net.UnixAddr{Name: remote, Net: "unixgram"},

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/facebook/time v0.0.0-20250502163358-2079056834d4
+	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/common v0.63.0
 	github.com/prometheus/exporter-toolkit v0.13.2

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/facebook/time v0.0.0-20250502163358-2079056834d4/go.mod h1:F/UyAsLLE0
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=


### PR DESCRIPTION
Use a UUID-based filename for the local side of the UNIX domain socket connection. This avoids collisons that happen when multiple simultaneous scrapes happen.

Fixes: https://github.com/superq/chrony_exporter/issues/103