### PR TITLE
Upgrade golang to 1.25.1 and upgrade golangci-lint to v2.4.0

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v2.1.5
+GOLANGCI_LINT_VERSION ?= v2.4.0
 GOLANGCI_FMT_OPTS ?=
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superq/chrony_exporter
 
-go 1.23.0
+go 1.25.1
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
### Why do I do this?

I'm seeing excessive CPU throttling with `chrony-exporter`.
I expect the[Container-aware GOMAXPROCS](https://tip.golang.org/doc/go1.25#container-aware-gomaxprocs) change in `go1.25` would help.