### PR TITLE
Skip ntpdata collection for reference clocks

### DIFF
--- a/collector/sources.go
+++ b/collector/sources.go
@@ -208,7 +208,8 @@ func (e Exporter) getSourcesMetrics(logger *slog.Logger, ch chan<- prometheus.Me
 		ch <- sourcesStateInfo.mustNewConstMetric(1.0, sourceAddress, sourceName, r.State.String(), r.Mode.String())
 		ch <- sourcesStratum.mustNewConstMetric(float64(r.Stratum), sourceAddress, sourceName)
 
-		if collectNtpdata {
+		// Skip NTP data collection for reference clocks as they don't have NTP protocol data
+		if collectNtpdata && r.Mode != chrony.SourceModeRef {
 			ntpDataPacket, err := client.Communicate(chrony.NewNTPDataPacket(r.IPAddr))
 			if err != nil {
 				return fmt.Errorf("failed to get ntpdata response for: %s", r.IPAddr)


### PR DESCRIPTION
## Summary

- Skip ntpdata collection for reference clocks (SourceModeRef) since they don't have NTP protocol data

Reference clocks use a different protocol than NTP sources, so attempting to collect ntpdata for them results in errors. This change adds a check to skip ntpdata collection when the source mode is `SourceModeRef`.

## Test plan

- [x] Test with a chrony instance that has reference clock sources configured
- [x] Verify that sources collection works correctly with `--collector.sources.with-ntpdata` enabled
- [x] Verify that regular NTP sources still have ntpdata collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)