### PR TITLE
Fix reference clock source handling

### DIFF
--- a/collector/sources.go
+++ b/collector/sources.go
@@ -196,7 +196,9 @@ func (e Exporter) getSourcesMetrics(logger *slog.Logger, ch chan<- prometheus.Me
 		sourceName := e.dnsLookup(logger, r.IPAddr.ToNetIP())
 
 		if r.Mode == chrony.SourceModeRef && r.IPAddr.ToNetIP().To4() != nil {
-			sourceName = chrony.RefidToString(binary.BigEndian.Uint32(r.IPAddr.ToNetIP().To4()))
+			refid := chrony.RefidToString(binary.BigEndian.Uint32(r.IPAddr.ToNetIP().To4()))
+			sourceAddress = refid
+			sourceName = refid
 		}
 
 		// Compute the reachability from the Reachability bits.
@@ -212,7 +214,8 @@ func (e Exporter) getSourcesMetrics(logger *slog.Logger, ch chan<- prometheus.Me
 		ch <- sourcesStateInfo.mustNewConstMetric(1.0, sourceAddress, sourceName, r.State.String(), r.Mode.String())
 		ch <- sourcesStratum.mustNewConstMetric(float64(r.Stratum), sourceAddress, sourceName)
 
-		if collectNtpdata {
+		// Skip NTP data collection for reference clocks as they don't have NTP protocol data
+		if collectNtpdata && r.Mode != chrony.SourceModeRef {
 			ntpDataPacket, err := client.Communicate(chrony.NewNTPDataPacket(r.IPAddr))
 			if err != nil {
 				return fmt.Errorf("failed to get ntpdata response for: %s", r.IPAddr)


### PR DESCRIPTION
## Summary
- Set `sourceAddress` to RefID string for reference clocks, not just `sourceName`. This ensures metrics show "GPS", "PPS", etc. instead of IP-like addresses derived from the RefID bytes (e.g., "71.80.83.0").
- Skip NTP data collection for reference clocks since they don't have NTP protocol data (they're local hardware clocks).

## Test plan
- [x] Deploy to a system with reference clock sources (GPS, PPS, etc.)
- [x] Verify `source_address` label shows RefID string instead of IP-like address
- [x] Verify NTP data metrics are not collected for reference clocks
- [x] Verify regular NTP sources still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)