### PR TITLE
sourcestats: fix for nil report

### DIFF
--- a/collector/sourcestats.go
+++ b/collector/sourcestats.go
@@ -125,6 +125,10 @@ func (e Exporter) getSourcestatsMetrics(logger *slog.Logger, ch chan<- prometheu
 	}
 
 	for _, r := range results {
+		if r.IPAddr == nil {
+			logger.Debug("Skipping source with nil IP address")
+			continue
+		}
 		sourceAddress := r.IPAddr.String()
 		sourceName := e.dnsLookup(logger, r.IPAddr)
 


### PR DESCRIPTION
This fixes #153, problem is that `nil` appears in the values rather than labels as a result of problems with dnsLookups; this skips any sources with `nil` as the IP. Now stats populate correctly in /metrics, including `sourcestats` metrics; prometheus seems happy; and stats are working in grafana.

```
...
# HELP chrony_sourcestats_frequency_ppms The estimated residual frequency for the server, in parts per million.
# TYPE chrony_sourcestats_frequency_ppms gauge
chrony_sourcestats_frequency_ppms{source_address="129.6.15.28",source_name="time-a-g.nist.gov"} 0.5672286152839661
chrony_sourcestats_frequency_ppms{source_address="132.163.96.1",source_name="time-a-b.nist.gov"} 0.43210569024086
chrony_sourcestats_frequency_ppms{source_address="172.104.209.204",source_name="172-104-209-204.ip.linodeusercontent.com"} 0.13307128846645355
...
```