### PR TITLE
Add clients collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Flags:
                                  Extend sources with ntpdata metrics (requires socket connection)
       --[no-]collector.serverstats  
                                  Collect serverstats metrics
+      --[no-]collector.clients   Collect clients metrics
       --[no-]collector.chmod-socket  
                                  Chmod 0666 the receiving unix datagram socket
       --[no-]collector.dns-lookups  
@@ -92,6 +93,32 @@ In case chrony is configured to not accept command messages via UDP (`cmdport 0`
 In this case use the command line option `--chrony.address=unix:///path/to/chronyd.sock` to configure the path to the chrony command socket.
 On most systems chrony will be listenting on `unix:///run/chrony/chronyd.sock`. For this to work the exporter needs to run as root or the same user as chrony.
 When the exporter is run as root the flag `collector.chmod-socket` is needed as well.
+
+### Clients collector
+
+`--collector.clients` summarizes chronyd's client log, the same data shown by
+`chronyc clients`, into a few aggregate metrics with no per-client labels, so
+the number of series stays the same no matter how many clients connect:
+
+* `chrony_clients_connected{protocol}` counts the clients in the log, split
+  into `nts` (clients that completed an NTS-KE handshake) and `ntp` (the rest).
+* `chrony_clients_last_ntp_hit_ago_seconds` and `chrony_clients_ntp_interval_seconds`
+  are histograms of how recently each client was seen and how often it polls.
+* `chrony_clients_ntp_drops` is a histogram of how many NTP requests were
+  dropped (rate limited) per client.
+
+This needs chrony 4.0 or later. The command it uses reports NTS-KE statistics,
+which chronyd only gained with NTS support in 4.0. Older versions do not know
+the command and reject the request, so the scrape sets `chrony_up` to 0.
+
+The client log size is set by
+[`clientloglimit`](https://chrony-project.org/doc/4.5/chrony.conf.html#clientloglimit)
+in `chrony.conf`. This is a limit in bytes, 512 KiB by default, which chronyd
+uses to hold a power-of-two number of records, around 4096 with the default.
+When the log is full chronyd reuses the oldest records, so the connected count
+stops at that limit. Increase `clientloglimit` to track more clients, but note
+that it is real memory (up to 2 GB), so set it to match the number of clients
+you expect.
 
 ## Prometheus Rules
 

--- a/collector/clients.go
+++ b/collector/clients.go
@@ -1,0 +1,210 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"log/slog"
+	"math"
+
+	"github.com/facebook/time/ntp/chrony"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	clientsSubsystem = "clients"
+
+	// intervalInvalid matches chrony's clientlog: an interval rate >= 127
+	// means chronyd has no average interval for the client yet, which
+	// chronyc renders as "-".
+	intervalInvalid int8 = 127
+
+	// lastHitNever is the (uint32)-1 sentinel chronyd uses for a "last hit
+	// ago" that never happened, rendered as "-" by chronyc.
+	lastHitNever uint32 = 0xFFFFFFFF
+)
+
+// clientsTimeBuckets are the upper bounds, in seconds, for the last-seen and
+// NTP-interval histograms. They cover the 1 second to 1 day range requested in
+// SuperQ/chrony_exporter#136.
+var clientsTimeBuckets = []float64{1, 5, 30, 60, 300, 1800, 3600, 21600, 86400}
+
+// clientsDropBuckets are the upper bounds (counts) for the per-client NTP drop
+// histogram.
+var clientsDropBuckets = []float64{0, 1, 2, 5, 10, 50, 100}
+
+var (
+	clientsConnected = typedDesc{
+		prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, clientsSubsystem, "connected"),
+			"The number of clients in chronyd's log. The protocol label is \"nts\" for clients that completed an NTS-KE handshake and \"ntp\" for the rest. Saturates at the client log size (clientloglimit).",
+			[]string{"protocol"},
+			nil,
+		),
+		prometheus.GaugeValue,
+	}
+
+	clientsLastNTPHitAgo = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, clientsSubsystem, "last_ntp_hit_ago_seconds"),
+		"Histogram of the time since the last NTP request from each client, in seconds. Clients that have not sent an NTP request are not included.",
+		nil,
+		nil,
+	)
+
+	clientsNTPInterval = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, clientsSubsystem, "ntp_interval_seconds"),
+		"Histogram of the mean interval between NTP requests from each client, in seconds. Clients that chronyd has not measured an interval for, such as those seen only once, are not included.",
+		nil,
+		nil,
+	)
+
+	clientsNTPDrops = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, clientsSubsystem, "ntp_drops"),
+		"Histogram of the number of NTP requests dropped (rate limited) per client.",
+		nil,
+		nil,
+	)
+)
+
+// clientsAggregate accumulates per-client statistics across all pages of a
+// 'clients' reply into the aggregate metrics exported by the collector.
+type clientsAggregate struct {
+	ntpClients uint64
+	ntsClients uint64
+
+	lastHitCount uint64
+	lastHitSum   float64
+	lastHitBkts  map[float64]uint64
+
+	intervalCount uint64
+	intervalSum   float64
+	intervalBkts  map[float64]uint64
+
+	dropsCount uint64
+	dropsSum   float64
+	dropsBkts  map[float64]uint64
+}
+
+func newClientsAggregate() *clientsAggregate {
+	return &clientsAggregate{
+		lastHitBkts:  newBuckets(clientsTimeBuckets),
+		intervalBkts: newBuckets(clientsTimeBuckets),
+		dropsBkts:    newBuckets(clientsDropBuckets),
+	}
+}
+
+// add folds a single client's statistics into the aggregate.
+func (a *clientsAggregate) add(c chrony.ClientAccess) {
+	// A client that has completed an NTS-KE handshake counts as nts.
+	if c.NKEHits > 0 {
+		a.ntsClients++
+	} else {
+		a.ntpClients++
+	}
+
+	// The drops histogram covers clients that sent or attempted NTP, so a
+	// fully rate-limited client (NTPHits == 0, NTPDrops > 0) still counts.
+	if c.NTPHits > 0 || c.NTPDrops > 0 {
+		drops := float64(c.NTPDrops)
+		a.dropsCount++
+		a.dropsSum += drops
+		observeBucket(a.dropsBkts, clientsDropBuckets, drops)
+	}
+
+	// The time histograms cover only clients that have served NTP.
+	if c.NTPHits == 0 {
+		return
+	}
+
+	if c.LastNTPHitAgo != lastHitNever {
+		lastSeen := float64(c.LastNTPHitAgo)
+		a.lastHitCount++
+		a.lastHitSum += lastSeen
+		observeBucket(a.lastHitBkts, clientsTimeBuckets, lastSeen)
+	}
+
+	// NTPInterval is a log2 seconds value; skip the no-interval sentinel.
+	if c.NTPInterval < intervalInvalid {
+		interval := math.Exp2(float64(c.NTPInterval))
+		a.intervalCount++
+		a.intervalSum += interval
+		observeBucket(a.intervalBkts, clientsTimeBuckets, interval)
+	}
+}
+
+// collect emits the accumulated aggregate as prometheus metrics.
+func (a *clientsAggregate) collect(ch chan<- prometheus.Metric) {
+	ch <- clientsConnected.mustNewConstMetric(float64(a.ntpClients), "ntp")
+	ch <- clientsConnected.mustNewConstMetric(float64(a.ntsClients), "nts")
+
+	ch <- prometheus.MustNewConstHistogram(clientsLastNTPHitAgo, a.lastHitCount, a.lastHitSum, a.lastHitBkts)
+	ch <- prometheus.MustNewConstHistogram(clientsNTPInterval, a.intervalCount, a.intervalSum, a.intervalBkts)
+	ch <- prometheus.MustNewConstHistogram(clientsNTPDrops, a.dropsCount, a.dropsSum, a.dropsBkts)
+}
+
+func (e Exporter) getClientsMetrics(logger *slog.Logger, ch chan<- prometheus.Metric, client *chrony.Client) error {
+	agg := newClientsAggregate()
+
+	firstIndex := uint32(0)
+	for {
+		packet, err := client.Communicate(chrony.NewClientAccessesByIndexPacket(firstIndex, chrony.MaxClientAccessesByIndex, 0))
+		if err != nil {
+			return err
+		}
+		logger.Debug("Got 'clients' response", "clients_packet", packet.GetStatus())
+
+		clients, ok := packet.(*chrony.ReplyClientAccessesByIndex)
+		if !ok {
+			return fmt.Errorf("got wrong 'clients' response: %q", packet)
+		}
+
+		for _, c := range clients.Clients {
+			agg.add(c)
+		}
+
+		// A page can hold fewer than MaxClientAccessesByIndex clients while the
+		// table still has slots to scan, so page until NextIndex reaches
+		// NIndices (the table size), like chronyc does. The NextIndex <=
+		// firstIndex check stops a non-advancing reply from looping forever.
+		if clients.NextIndex >= clients.NIndices || clients.NextIndex <= firstIndex {
+			break
+		}
+		firstIndex = clients.NextIndex
+	}
+
+	agg.collect(ch)
+
+	return nil
+}
+
+// newBuckets returns a zero-initialized bucket map for the given upper bounds.
+// Seeding every bound makes MustNewConstHistogram emit all "le" series even
+// with no observations, keeping the series set stable across scrapes.
+func newBuckets(bounds []float64) map[float64]uint64 {
+	buckets := make(map[float64]uint64, len(bounds))
+	for _, ub := range bounds {
+		buckets[ub] = 0
+	}
+	return buckets
+}
+
+// observeBucket records value into its cumulative histogram buckets,
+// incrementing every bound that covers it.
+func observeBucket(buckets map[float64]uint64, bounds []float64, value float64) {
+	for _, ub := range bounds {
+		if value <= ub {
+			buckets[ub]++
+		}
+	}
+}

--- a/collector/clients_test.go
+++ b/collector/clients_test.go
@@ -1,0 +1,139 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"testing"
+
+	"github.com/facebook/time/ntp/chrony"
+)
+
+// Clients are split into ntp and nts by whether they completed an NTS-KE
+// handshake (NKEHits > 0). Every record counts towards one of the two.
+func TestClientsAggregateProtocolSplit(t *testing.T) {
+	agg := newClientsAggregate()
+	agg.add(chrony.ClientAccess{NTPHits: 5})             // ntp
+	agg.add(chrony.ClientAccess{NTPHits: 5, NKEHits: 2}) // nts
+	agg.add(chrony.ClientAccess{NTPHits: 1})             // ntp
+	agg.add(chrony.ClientAccess{CmdHits: 9})             // ntp (command only, no NKE)
+
+	if agg.ntpClients != 3 {
+		t.Errorf("ntpClients = %d, want 3", agg.ntpClients)
+	}
+	if agg.ntsClients != 1 {
+		t.Errorf("ntsClients = %d, want 1", agg.ntsClients)
+	}
+}
+
+func TestClientsAggregateDropsHistogram(t *testing.T) {
+	agg := newClientsAggregate()
+	agg.add(chrony.ClientAccess{NTPHits: 5, NTPDrops: 0}) // counted, 0 drops
+	agg.add(chrony.ClientAccess{NTPHits: 0, NTPDrops: 3}) // fully rate limited, still counted
+	agg.add(chrony.ClientAccess{NTPHits: 10, NTPDrops: 60})
+	agg.add(chrony.ClientAccess{CmdHits: 2}) // no NTP traffic, excluded from drops
+
+	if agg.dropsCount != 3 {
+		t.Fatalf("dropsCount = %d, want 3", agg.dropsCount)
+	}
+	if agg.dropsSum != 63 {
+		t.Errorf("dropsSum = %v, want 63", agg.dropsSum)
+	}
+	want := map[float64]uint64{0: 1, 1: 1, 2: 1, 5: 2, 10: 2, 50: 2, 100: 3}
+	for ub, w := range want {
+		if got := agg.dropsBkts[ub]; got != w {
+			t.Errorf("dropsBkts[%v] = %d, want %d", ub, got, w)
+		}
+	}
+}
+
+// Clients that have never served an NTP request are excluded from the time
+// histograms, but are still counted elsewhere.
+func TestClientsAggregateSkipsZeroNTPHits(t *testing.T) {
+	agg := newClientsAggregate()
+	agg.add(chrony.ClientAccess{NTPHits: 0, CmdHits: 9, LastNTPHitAgo: 5, NTPInterval: 3})
+	agg.add(chrony.ClientAccess{NTPHits: 1, LastNTPHitAgo: 5, NTPInterval: 3})
+
+	if agg.lastHitCount != 1 {
+		t.Errorf("lastHitCount = %d, want 1 (zero-NTPHits client must be skipped)", agg.lastHitCount)
+	}
+	if agg.intervalCount != 1 {
+		t.Errorf("intervalCount = %d, want 1", agg.intervalCount)
+	}
+}
+
+// chronyd reports a sentinel interval (>= 127) and a sentinel last-hit
+// (0xFFFFFFFF) for clients it has no average for; these are excluded from the
+// time histograms, matching chronyc's "-".
+func TestClientsAggregateSkipsSentinels(t *testing.T) {
+	agg := newClientsAggregate()
+	agg.add(chrony.ClientAccess{NTPHits: 5, LastNTPHitAgo: 10, NTPInterval: 6})
+	agg.add(chrony.ClientAccess{NTPHits: 1, LastNTPHitAgo: 2, NTPInterval: 127})
+	agg.add(chrony.ClientAccess{NTPHits: 3, LastNTPHitAgo: 0xFFFFFFFF, NTPInterval: 4})
+
+	if agg.lastHitCount != 2 {
+		t.Errorf("lastHitCount = %d, want 2", agg.lastHitCount)
+	}
+	if agg.lastHitSum != 12 {
+		t.Errorf("lastHitSum = %v, want 12", agg.lastHitSum)
+	}
+	if agg.intervalCount != 2 {
+		t.Errorf("intervalCount = %d, want 2", agg.intervalCount)
+	}
+	// 2^6 + 2^4 = 64 + 16 = 80.
+	if agg.intervalSum != 80 {
+		t.Errorf("intervalSum = %v, want 80", agg.intervalSum)
+	}
+}
+
+func TestClientsAggregateTimeHistograms(t *testing.T) {
+	agg := newClientsAggregate()
+	// LastNTPHitAgo values 3, 50, 3000; NTPInterval 0, 6, 6 -> 1s, 64s, 64s.
+	agg.add(chrony.ClientAccess{NTPHits: 1, LastNTPHitAgo: 3, NTPInterval: 0})
+	agg.add(chrony.ClientAccess{NTPHits: 1, LastNTPHitAgo: 50, NTPInterval: 6})
+	agg.add(chrony.ClientAccess{NTPHits: 1, LastNTPHitAgo: 3000, NTPInterval: 6})
+
+	if agg.lastHitSum != 3053 {
+		t.Errorf("lastHitSum = %v, want 3053", agg.lastHitSum)
+	}
+	wantLast := map[float64]uint64{1: 0, 5: 1, 30: 1, 60: 2, 300: 2, 1800: 2, 3600: 3, 21600: 3, 86400: 3}
+	for ub, w := range wantLast {
+		if got := agg.lastHitBkts[ub]; got != w {
+			t.Errorf("lastHitBkts[%v] = %d, want %d", ub, got, w)
+		}
+	}
+
+	if agg.intervalSum != 129 {
+		t.Errorf("intervalSum = %v, want 129", agg.intervalSum)
+	}
+	wantInterval := map[float64]uint64{1: 1, 5: 1, 30: 1, 60: 1, 300: 3, 1800: 3, 3600: 3, 21600: 3, 86400: 3}
+	for ub, w := range wantInterval {
+		if got := agg.intervalBkts[ub]; got != w {
+			t.Errorf("intervalBkts[%v] = %d, want %d", ub, got, w)
+		}
+	}
+}
+
+func TestNewBucketsSeedsAllBounds(t *testing.T) {
+	for _, bounds := range [][]float64{clientsTimeBuckets, clientsDropBuckets} {
+		buckets := newBuckets(bounds)
+		if len(buckets) != len(bounds) {
+			t.Fatalf("newBuckets len = %d, want %d", len(buckets), len(bounds))
+		}
+		for _, ub := range bounds {
+			if _, ok := buckets[ub]; !ok {
+				t.Errorf("newBuckets missing bound %v", ub)
+			}
+		}
+	}
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -61,6 +61,7 @@ type Exporter struct {
 	collectNtpdata     bool
 	collectTracking    bool
 	collectServerstats bool
+	collectClients     bool
 	chmodSocket        bool
 	dnsLookups         bool
 
@@ -98,6 +99,8 @@ type ChronyCollectorConfig struct {
 	CollectTracking bool
 	// CollectServerstats will configure the exporter to collect `chronyc serverstats`.
 	CollectServerstats bool
+	// CollectClients will configure the exporter to collect `chronyc clients`.
+	CollectClients bool
 }
 
 func NewExporter(conf ChronyCollectorConfig, logger *slog.Logger) Exporter {
@@ -110,6 +113,7 @@ func NewExporter(conf ChronyCollectorConfig, logger *slog.Logger) Exporter {
 		collectNtpdata:     conf.CollectNtpdata,
 		collectTracking:    conf.CollectTracking,
 		collectServerstats: conf.CollectServerstats,
+		collectClients:     conf.CollectClients,
 		chmodSocket:        conf.ChmodSocket,
 		dnsLookups:         conf.DNSLookups,
 
@@ -197,6 +201,14 @@ func (e Exporter) Collect(ch chan<- prometheus.Metric) {
 		err = e.getServerstatsMetrics(logger, ch, &client)
 		if err != nil {
 			logger.Debug("Couldn't get serverstats", "err", err)
+			up = 0
+		}
+	}
+
+	if e.collectClients {
+		err = e.getClientsMetrics(logger, ch, &client)
+		if err != nil {
+			logger.Debug("Couldn't get clients", "err", err)
 			up = 0
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/facebook/time v0.0.0-20260325194334-c70c13bedb97
+	github.com/facebook/time v0.0.0-20260604194729-8522b1637c7e
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.68.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/facebook/time v0.0.0-20260325194334-c70c13bedb97 h1:wwKhJEBXoHoy0zHiGDUZly56y98Bl+c+UeBVmRXaAnM=
-github.com/facebook/time v0.0.0-20260325194334-c70c13bedb97/go.mod h1:98ab4DtT6gMljAQ6j1cO+68lnB8XfpGKVZtL9FQvsTs=
+github.com/facebook/time v0.0.0-20260604194729-8522b1637c7e h1:d1JXzURUpsXcf2pmE3BZVbG7e+eZcvRQSLHZqoQtYmc=
+github.com/facebook/time v0.0.0-20260604194729-8522b1637c7e/go.mod h1:sbXd8MxicNxCm6DrrrswkNzXkkXcqP5080oMWmnPFKY=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/main.go
+++ b/main.go
@@ -73,6 +73,11 @@ func main() {
 	).Default("false").BoolVar(&conf.CollectServerstats)
 
 	kingpin.Flag(
+		"collector.clients",
+		"Collect clients metrics",
+	).Default("false").BoolVar(&conf.CollectClients)
+
+	kingpin.Flag(
 		"collector.chmod-socket",
 		"Chmod 0666 the receiving unix datagram socket",
 	).Default("false").BoolVar(&conf.ChmodSocket)


### PR DESCRIPTION
Fixes #136.

This adds an optional collector for chronyd's client log, the data you see from `chronyc clients`. It builds on the `REQ_CLIENT_ACCESSES_BY_INDEX` support that was recently merged into facebook/time (facebook/time#522), and bumps the dependency to a version that includes it.

The collector is off by default and turned on with `--collector.clients`. It requires chrony 4.0 or later, because the command it uses reports NTS-KE statistics that older chronyd does not have.

### Metrics

Everything is aggregated over the whole client log with no per-client labels, so the number of series does not grow with the number of clients:

* `chrony_clients_connected`: number of clients in the log
* `chrony_clients_ntp_hits`, `chrony_clients_nke_hits`, `chrony_clients_cmd_hits`: requests received
* `chrony_clients_ntp_drops`, `chrony_clients_nke_drops`, `chrony_clients_cmd_drops`: requests dropped (rate limited)
* `chrony_clients_last_ntp_hit_ago_seconds`: histogram of each client's last-seen time
* `chrony_clients_ntp_interval_seconds`: histogram of each client's mean NTP interval

### Why gauges instead of `_total` counters

The hit and drop metrics are gauges on purpose. chronyd's client log has a fixed size (`clientloglimit`) and reuses the oldest records once it is full, so these sums can go down as clients are dropped. Exposing them as counters would make `rate()` produce false spikes on a busy server. For monotonic, server-wide request totals the serverstats collector is already the right source.

### Testing

Verified against a live chronyd with the default `clientloglimit`, where the client log had filled up to its limit. `chrony_clients_connected` matched `chronyc -n clients`, and the two histograms matched the expected distributions. The sentinel values chronyd uses for "no interval yet" and "never hit" are excluded, just as chronyc renders them as `-`.