### PR TITLE
Add optional Debian packaging (nfpm .deb + systemd unit)

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,131 @@
+---
+name: Debian package
+on:
+  pull_request:
+  push:
+    branches: [main, master, 'release-*']
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build .deb
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - run: make deb
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: chrony-exporter-deb
+          path: chrony-exporter_*_amd64.deb
+          retention-days: 7
+
+  verify:
+    name: Verify package (systemd + chronyd)
+    runs-on: ubuntu-24.04
+    needs: [build]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: chrony-exporter-deb
+
+      # Runs the just-built .deb under real systemd + real chronyd in a
+      # nested, privileged container to prove the unit actually works, not
+      # just that nfpm produced a file.
+      - name: Build systemd test image
+        run: docker build --tag chrony-exporter-citest -f packaging/ci/Dockerfile.systemd-test packaging/ci/
+
+      - name: Boot systemd container
+        run: |
+          set -eu
+          # --cgroupns=host (not a manual /sys/fs/cgroup bind mount) and
+          # -e container=docker (systemd checks this to behave correctly
+          # under containerization) are both required for systemd to come
+          # up as PID 1 in a container.
+          docker run -d --name chrony-exporter-verify --privileged --cgroupns=host \
+            -e container=docker \
+            --tmpfs /run --tmpfs /run/lock \
+            chrony-exporter-citest
+
+      - name: Wait for chrony to be active
+        run: |
+          set -eu
+          for i in $(seq 1 60); do
+            state=$(docker exec chrony-exporter-verify systemctl is-active chrony 2>&1) && break
+            echo "waiting for chrony ($i/60): $state"
+            sleep 1
+          done
+          docker exec chrony-exporter-verify systemctl is-active chrony
+
+      - name: Install the .deb and run checks
+        run: |
+          set -eu
+          DEB=$(ls chrony-exporter_*_amd64.deb)
+          docker cp "$DEB" chrony-exporter-verify:/root/"$DEB"
+          # dpkg -i, not apt-get install <path>: the package has no runtime
+          # deps (static Go binary), so there's nothing for apt to resolve.
+          docker exec chrony-exporter-verify dpkg -i /root/"$DEB"
+
+          docker exec chrony-exporter-verify bash -eu -c '
+            check() { echo "-- check: $1"; }
+
+            # --collector.chmod-socket is required here: without it chronyd
+            # rejects the exporter checks even though it is running as root.
+            echo "ARGS=\"--chrony.address=unix:///run/chrony/chronyd.sock --web.listen-address=:9123 --collector.chmod-socket\"" > /etc/default/chrony_exporter@primary
+            systemctl daemon-reload
+            systemctl enable --now chrony_exporter@primary.service
+            sleep 1
+            systemctl status chrony_exporter@primary.service --no-pager || true
+
+            check "User=root"
+            ACTUAL_USER=$(systemctl show chrony_exporter@primary.service -p User --value)
+            echo "got: [$ACTUAL_USER]"
+            [ "$ACTUAL_USER" = "root" ]
+
+            check "chrony_up == 1"
+            curl -sf localhost:9123/metrics | grep -qx "chrony_up 1"
+
+            # No ExecReload on this unit (see the unit file comment): confirm
+            # `systemctl reload` is cleanly rejected rather than silently
+            # killing the exporter with no auto-recovery (SIGHUP is a
+            # systemd "clean" exit by default, so Restart=on-failure never
+            # fires after it).
+            check "reload is rejected (no ExecReload), not silently fatal"
+            PID_BEFORE=$(systemctl show chrony_exporter@primary.service -p MainPID --value)
+            systemctl reload chrony_exporter@primary.service 2>&1 && RELOAD_RC=0 || RELOAD_RC=$?
+            echo "reload exit code: $RELOAD_RC"
+            [ "$RELOAD_RC" != "0" ]
+            PID_AFTER=$(systemctl show chrony_exporter@primary.service -p MainPID --value)
+            [ "$PID_BEFORE" = "$PID_AFTER" ]
+
+            check "drop-in CPUAffinity applies"
+            mkdir -p /etc/systemd/system/chrony_exporter@primary.service.d
+            printf "[Service]\nCPUAffinity=0-2\n" > /etc/systemd/system/chrony_exporter@primary.service.d/test.conf
+            systemctl daemon-reload
+            systemctl restart chrony_exporter@primary.service
+            sleep 1
+            ACTUAL_AFFINITY=$(systemctl show chrony_exporter@primary.service -p CPUAffinity --value)
+            echo "got: [$ACTUAL_AFFINITY]"
+            [ "$ACTUAL_AFFINITY" = "0-2" ]
+
+            check "remove leaves admin-created files in place"
+            dpkg -r chrony-exporter
+            [ -f /etc/default/chrony_exporter@primary ]
+            [ -f /etc/systemd/system/chrony_exporter@primary.service.d/test.conf ]
+
+            echo "verify: all checks passed"
+          '
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f chrony-exporter-verify || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /chrony_exporter
+/.build/
+*.deb

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,27 @@ DOCKER_IMAGE_NAME ?= chrony-exporter
 DOCKER_REPO       ?= superq
 
 include Makefile.common
+
+# Debian packaging (see packaging/ and nfpm.yaml). Not part of `all`/`build`;
+# invoke explicitly with `make deb`.
+NFPM_VERSION ?= 2.39.0
+NFPM         := $(FIRST_GOPATH)/bin/nfpm
+PKG_VERSION  := $(shell cat VERSION)
+
+.PHONY: nfpm
+nfpm: $(NFPM)
+
+$(NFPM):
+	@echo ">> installing nfpm $(NFPM_VERSION)"
+	mkdir -p $(FIRST_GOPATH)/bin
+	$(eval NFPM_TMP := $(shell mktemp -d))
+	curl -sL https://github.com/goreleaser/nfpm/releases/download/v$(NFPM_VERSION)/nfpm_$(NFPM_VERSION)_Linux_x86_64.tar.gz | tar -xzf - -C $(NFPM_TMP) nfpm
+	cp $(NFPM_TMP)/nfpm $(NFPM)
+	rm -r $(NFPM_TMP)
+
+.PHONY: deb
+deb: promu nfpm
+	@echo ">> building linux/amd64 binary for packaging"
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(PROMU) build --prefix .build/linux-amd64
+	@echo ">> building chrony-exporter_$(PKG_VERSION)_amd64.deb"
+	PKG_VERSION=$(PKG_VERSION) $(NFPM) package --config nfpm.yaml --packager deb --target chrony-exporter_$(PKG_VERSION)_amd64.deb

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ You can build a Docker container with the included `docker` make target:
 
 This will not even require Go tooling on the host.
 
+### Building a Debian package
+
+You can build a `.deb` package with the included `deb` make target:
+
+    make deb
+
+This produces `chrony-exporter_<version>_amd64.deb`, built via
+[nfpm](https://nfpm.goreleaser.com/) from the config in `nfpm.yaml`. It
+installs the binary to `/usr/bin/chrony_exporter` along with a
+`chrony_exporter@.service` systemd template unit (see `packaging/`), so
+instances are managed as `chrony_exporter@<name>.service` with their flags in
+`/etc/default/chrony_exporter@<name>` (see
+`packaging/doc/chrony_exporter.env.example`). The unit runs the exporter as
+`root`, matching the `--collector.chmod-socket` requirement described below
+for reading chrony's unix command socket.
+
 ### Running in a container
 
 Because chrony only listens on the host localhost, you need to adjust the default chrony address

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,26 @@
+name: chrony-exporter
+arch: amd64
+platform: linux
+# nfpm expands env vars in string fields; the `deb` Makefile target sets this
+# from the repo's VERSION file before invoking nfpm.
+version: ${PKG_VERSION}
+version_schema: none
+maintainer: Rogan Lynch <roganl@gmail.com>
+description: |
+  Prometheus exporter for chrony NTP statistics.
+homepage: https://github.com/SuperQ/chrony_exporter
+license: Apache-2.0
+
+contents:
+  - src: .build/linux-amd64/chrony_exporter
+    dst: /usr/bin/chrony_exporter
+  - src: LICENSE
+    dst: /usr/share/doc/chrony-exporter/LICENSE
+  - src: packaging/chrony_exporter@.service
+    dst: /lib/systemd/system/chrony_exporter@.service
+  - src: packaging/doc/chrony_exporter.env.example
+    dst: /usr/share/doc/chrony-exporter/chrony_exporter.env.example
+
+scripts:
+  postinstall: packaging/postinstall.sh
+  postremove: packaging/postremove.sh

--- a/packaging/chrony_exporter@.service
+++ b/packaging/chrony_exporter@.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Prometheus exporter for chrony NTP statistics (%i)
+Documentation=https://github.com/SuperQ/chrony_exporter
+After=network-online.target chrony.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+# root, not nobody: the README documents that the exporter needs to run as
+# root (or the same user as chrony) to use the unix command socket most
+# chrony installs listen on, and that running as root requires
+# --collector.chmod-socket. No hardening directives (NoNewPrivileges,
+# ProtectSystem, ProtectHome, Group=) for the same reason -- they'd conflict
+# with root + raw socket access.
+User=root
+EnvironmentFile=/etc/default/chrony_exporter@%i
+ExecStart=/usr/bin/chrony_exporter $ARGS
+# No ExecReload: chrony_exporter has no SIGHUP handler, and systemd treats
+# SIGHUP as a "clean" exit by default, so Restart=on-failure never fires
+# after `kill -HUP` kills it -- `systemctl reload` would silently and
+# permanently kill the exporter with no auto-recovery. `systemctl restart`
+# already does a full clean cycle in under a second; there's no working
+# reload to keep.
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=20s
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/ci/Dockerfile.systemd-test
+++ b/packaging/ci/Dockerfile.systemd-test
@@ -1,0 +1,14 @@
+FROM debian:trixie
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        systemd systemd-sysv chrony ca-certificates curl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Minimal, network-independent config: local stratum 10 lets chronyd start and
+# open its real command socket with no NTP peers/internet reachability needed
+# from inside the CI runner.
+RUN printf 'local stratum 10\nbindcmdaddress /run/chrony/chronyd.sock\n' > /etc/chrony/chrony.conf
+
+STOPSIGNAL SIGRTMIN+3
+CMD ["/lib/systemd/systemd"]

--- a/packaging/doc/chrony_exporter.env.example
+++ b/packaging/doc/chrony_exporter.env.example
@@ -1,0 +1,12 @@
+# Example env file for a chrony_exporter@<instance>.service instance.
+# The package does NOT install a live copy of this anywhere -- instance names
+# and their flags are host-specific. Create one at:
+#   /etc/default/chrony_exporter@<instance>
+# to match the instance name used with `systemctl enable --now
+# chrony_exporter@<instance>.service`, e.g. /etc/default/chrony_exporter@primary
+# for `chrony_exporter@primary.service`.
+#
+# Most installs need --chrony.address pointed at chrony's unix command socket,
+# which requires this unit's User=root plus --collector.chmod-socket (see the
+# main README: https://github.com/SuperQ/chrony_exporter#readme).
+ARGS="--collector.tracking --collector.sources --collector.serverstats --chrony.address=unix:///run/chrony/chronyd.sock --collector.chmod-socket"

--- a/packaging/postinstall.sh
+++ b/packaging/postinstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+systemctl daemon-reload || true

--- a/packaging/postremove.sh
+++ b/packaging/postremove.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+systemctl daemon-reload || true


### PR DESCRIPTION
## Summary

Adds optional, opt-in Debian packaging support. This does not change any
existing build/release path (promu tarballs, container images) — it's a new
`make deb` target plus a new, separate GitHub Actions workflow.

* `nfpm.yaml` — [nfpm](https://nfpm.goreleaser.com/) config that packages the
  promu-built binary into a `.deb`.
* `packaging/chrony_exporter@.service` — a `chrony_exporter@.service` systemd
  template unit, so instances run as `chrony_exporter@<name>.service` with
  per-instance flags in `/etc/default/chrony_exporter@<name>`. Runs as `root`,
  matching the `--collector.chmod-socket` requirement already documented in
  the README for reading chrony's unix command socket. Deliberately has no
  `ExecReload`: `chrony_exporter` has no SIGHUP handler, and systemd treats
  SIGHUP as a "clean" exit by default, so `Restart=on-failure` never fires
  after `kill -HUP` — `systemctl reload` would silently and permanently kill
  the exporter with no auto-recovery. `systemctl restart` already does a full
  cycle in under a second, so there's no working reload behaviour to keep.
* `packaging/postinstall.sh` / `packaging/postremove.sh` — just
  `systemctl daemon-reload`.
* `packaging/doc/chrony_exporter.env.example` — documents the per-instance env
  file format (not installed live, since instance names/flags are host-specific).
* `Makefile` — new `deb` target: cross-builds a linux/amd64 binary with promu
  and packages it with nfpm. Not wired into `all`/`build`, so it has zero
  effect on the existing build unless invoked explicitly.
* `.github/workflows/deb.yml` — new, self-contained workflow: builds the
  package, then boots it under **real systemd + chronyd** in a privileged
  container to verify the unit actually works — starts as the right user,
  serves `chrony_up 1`, correctly rejects `systemctl reload` without killing
  the process, honours a systemd drop-in, and leaves admin-created files in
  place on `dpkg -r`. No publish step, no secrets required.

## Background

I maintain an internal fork/mirror of this project and built this packaging
against our internal GitLab CI to replace some hand-placed
`/usr/local/bin/chrony_exporter` + hand-authored systemd unit deployments
(which is actually how the "no ExecReload" issue above was discovered — the
old hand-authored units had it, and it was silently killing the exporter on
`reload`). I think it's generically useful, so I've pulled it out and adapted
it to standalone, upstreamable form:

* Dropped everything that was actually internal-infrastructure-specific: a
  private-apt-repo publish step (scp to an internal host with a deploy key),
  and a GitLab-only tag-dispatch job that exists purely to work around GitLab
  CE not having "pipelines on mirror update" (not applicable here — GitHub
  Actions already triggers natively on tag push).
* What's left is the actual packaging content (nfpm config, systemd unit,
  scripts) and the systemd/chronyd verification logic, both of which are
  fully generic and were the valuable, hard-won parts (getting systemd to
  boot cleanly in a container, working out the ExecReload issue, etc.).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean (no Go source
      touched by this change).
- [x] `make deb` locally (macOS/arm64 host): cross-builds via
      `GOOS=linux GOARCH=amd64 promu build`, verified the output is a real
      linux/amd64 ELF binary. The nfpm packaging step itself needs a Linux
      host (nfpm ships Linux-only release binaries), so that part — and the
      full systemd/chronyd verify workflow — is exercised by CI on this PR.
- [ ] CI: `deb.yml` build + verify jobs pass.